### PR TITLE
signatures: add @SapphicMoe

### DIFF
--- a/content/posts/signatures.md
+++ b/content/posts/signatures.md
@@ -71,6 +71,7 @@ draft: false
 - pinkcreeper100 ([@pinkcreeper100](https://github.com/pinkcreeper100))
 - Leslie-Alexandre ([@eagleusb](https://github.com/eagleusb))
 - Reyu Zenfold ([@Reyu](https://github.com/Reyu))
+- Sapphic Angels ([@SapphicMoe](https://github.com/SapphicMoe))
 <!-- Insert your signature above here, using the format above.>
 
 ... and at least a dozen others who concur with this document, but are unable to sign for safety reasons.


### PR DESCRIPTION
We, the Sapphic Angels system [(*system?*)](https://morethanone.info/), are signing this open letter to call for the resignation of Eelco Dolstra from the NixOS Foundation board.