### PR TITLE
signatures: add Maxine Aubrey

### DIFF
--- a/content/posts/signatures.md
+++ b/content/posts/signatures.md
@@ -87,6 +87,7 @@ draft: false
 - June (strawberry) ([@girlbossceo](https://girlboss.ceo))
 - Ellie ([@eleonora](https://eleonora.gay))
 - Danielle Lancashire ([@endocrimes](https://github.com/endocrimes))
+- Maxine Aubrey ([@amaxine](https://github.com/amaxine))
 <!-- Insert your signature above here, using the format above.>
 
 ... and at least a dozen others who concur with this document, but are unable to sign for safety reasons.


### PR DESCRIPTION
Nix is on the brink due to the apathetic stance of the foundation towards many community problems, and the continued pursuit of neutrality and centrist balance on basic humanity. I would much rather see this result in the community finally being able to address this on-going situation than it cause a fork, but any path forward is preferable to the current status quo.